### PR TITLE
perf: merge user file processing worker into docprocessing

### DIFF
--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -70,20 +70,8 @@ stopasgroup=true
 command=celery -A onyx.background.celery.versioned_apps.docprocessing worker
     --loglevel=INFO
     --hostname=docprocessing@%%n
-    -Q docprocessing
+    -Q docprocessing,user_file_processing,user_file_project_sync,user_file_delete
 stdout_logfile=/var/log/celery_worker_docprocessing.log
-stdout_logfile_maxbytes=16MB
-redirect_stderr=true
-autorestart=true
-startsecs=10
-stopasgroup=true
-
-[program:celery_worker_user_file_processing]
-command=celery -A onyx.background.celery.versioned_apps.user_file_processing worker
-    --loglevel=INFO
-    --hostname=user_file_processing@%%n
-    -Q user_file_processing,user_file_project_sync,user_file_delete
-stdout_logfile=/var/log/celery_worker_user_file_processing.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true
 autorestart=true
@@ -159,7 +147,6 @@ command=tail -qF
     /var/log/celery_worker_light.log
     /var/log/celery_worker_heavy.log
     /var/log/celery_worker_docprocessing.log
-    /var/log/celery_worker_user_file_processing.log
     /var/log/celery_worker_docfetching.log
     /var/log/slack_bot.log
     /var/log/discord_bot.log


### PR DESCRIPTION
## Summary
- Adds `user_file_processing`, `user_file_project_sync`, `user_file_delete` queues to the docprocessing worker
- Removes the dedicated `celery_worker_user_file_processing` from supervisord
- Saves ~500 MB RAM by eliminating a redundant worker process with its own DB/Redis connections

Closes #16

## Test plan
- [ ] Deploy and run `docker exec onyx-background-1 supervisorctl status` — should NOT list `celery_worker_user_file_processing`
- [ ] Upload a user file and verify it gets processed (chunked, embedded, indexed) via the docprocessing worker
- [ ] Verify docprocessing worker logs show user file tasks being consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)