### PR TITLE
fix: prune stale git refs before deploy fetch

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -164,6 +164,7 @@ jobs:
             cd "$DEPLOY_DIR" || exit 1
 
             echo "[INFO] Updating code from release branch ($BRANCH)..."
+            git remote prune origin
             git fetch origin "$BRANCH"
             git checkout -- .
             git checkout "origin/$BRANCH"

--- a/.github/workflows/rollback-digitalocean.yml
+++ b/.github/workflows/rollback-digitalocean.yml
@@ -100,6 +100,7 @@ jobs:
             sudo cp -r . "$BACKUP_DIR"
 
             echo "[INFO] Syncing git references..."
+            git remote prune origin
             git fetch origin --tags
             git fetch origin main
 


### PR DESCRIPTION
## Summary
- Adds `git remote prune origin` before `git fetch` in both deploy and rollback workflows
- Prevents "cannot lock ref" errors when remote branch refs have moved (e.g. after force-push or direct push)

## Root cause
The droplet's local git cache had a stale ref for `origin/release-0.0.2`, causing `git fetch` to fail with:
```
error: cannot lock ref 'refs/remotes/origin/release-0.0.2': is at cc35f08 but expected ab9ff3c
```

## Test plan
- [ ] Re-run the deploy workflow — should succeed without ref lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)