### PR TITLE
fix: use default for OPENSEARCH_ADMIN_PASSWORD instead of required

### DIFF
--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -287,7 +287,7 @@ services:
       # We need discovery.type=single-node so that OpenSearch doesn't try
       # forming a cluster and waiting for other nodes to become live.
       - discovery.type=single-node
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:?OPENSEARCH_ADMIN_PASSWORD not set}
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123}
       # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
       # We do this to avoid unstable performance from page swaps.
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping.


### PR DESCRIPTION
## Summary
- Changes `${OPENSEARCH_ADMIN_PASSWORD:?...}` to `${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123}` in opensearch service
- The `:?` syntax makes `docker compose pull` fail at parse time even when opensearch is behind `profiles: ["opensearch-enabled"]`
- Docker Compose interpolates ALL environment variables regardless of profiles

## Root cause
```
error while interpolating services.opensearch.environment.[]: required variable OPENSEARCH_ADMIN_PASSWORD is missing a value
```

## Test plan
- [ ] Deploy workflow succeeds without `OPENSEARCH_ADMIN_PASSWORD` in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)