### PR TITLE
feat: add VictoriaMetrics time-series metrics store

### DIFF
--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -530,6 +530,39 @@ services:
         max-size: "50m"
         max-file: "6"
 
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.117.1
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    volumes:
+      - victoriametrics_data:/victoria-metrics-data
+      - ./victoriametrics/scrape.yml:/etc/victoriametrics/scrape.yml:ro
+    command:
+      - "-promscrape.config=/etc/victoriametrics/scrape.yml"
+      - "-retentionPeriod=${VICTORIAMETRICS_RETENTION:-30d}"
+      - "-storageDataPath=/victoria-metrics-data"
+      - "-httpListenAddr=:8428"
+    ports:
+      - "8428:8428"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8428/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+
   code-interpreter:
     image: onyxdotapp/code-interpreter:0.1.0
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
@@ -571,5 +604,7 @@ volumes:
   file-system:
   # Uptime Kuma persistent data
   uptime_kuma_data:
+  # VictoriaMetrics time-series data
+  victoriametrics_data:
   # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -67,6 +67,10 @@ DB_READONLY_PASSWORD=password
 # See https://docs.onyx.app/admins/connectors/overview for a full list of connectors
 SHOW_EXTRA_CONNECTORS=False
 
+# VictoriaMetrics (docker-compose.prod.yml)
+# Data retention period (default: 30 days)
+#VICTORIAMETRICS_RETENTION=30d
+
 # User File Upload Configuration
 # Skip the token count threshold check (100,000 tokens) for uploaded files
 # For self-hosted: set to true to skip for all users

--- a/deployment/docker_compose/victoriametrics/scrape.yml
+++ b/deployment/docker_compose/victoriametrics/scrape.yml
@@ -1,0 +1,38 @@
+# VictoriaMetrics scrape configuration
+# Compatible with Prometheus scrape_configs format.
+#
+# Exporter targets will be added here as they are deployed
+# (see issues #84, #85, #86).
+
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  # VictoriaMetrics self-monitoring
+  - job_name: victoriametrics
+    static_configs:
+      - targets: ["localhost:8428"]
+
+  # Uncomment as exporters are deployed:
+
+  # PostgreSQL exporter (#84)
+  # - job_name: postgres
+  #   static_configs:
+  #     - targets: ["postgres-exporter:9187"]
+
+  # Redis exporter (#84)
+  # - job_name: redis
+  #   static_configs:
+  #     - targets: ["redis-exporter:9121"]
+
+  # Celery exporter (#85)
+  # - job_name: celery
+  #   static_configs:
+  #     - targets: ["celery-exporter:9808"]
+
+  # FastAPI /metrics endpoint (#86)
+  # - job_name: fastapi
+  #   static_configs:
+  #     - targets: ["api_server:8080"]
+  #   metrics_path: /metrics


### PR DESCRIPTION
## Summary
- Adds VictoriaMetrics service to `docker-compose.prod.yml` as a lightweight Prometheus-compatible metrics store
- Includes scrape config with self-monitoring and commented-out targets for upcoming exporters (#84, #85, #86)
- 30-day retention, 512M RAM limit, healthcheck, persistent volume
- Compatible with Grafana PR #104 (`http://victoriametrics:8428` datasource)

Closes #82

## Test plan
- [ ] `docker compose -f docker-compose.prod.yml config` validates without errors
- [ ] VictoriaMetrics container starts and passes healthcheck
- [ ] `curl http://localhost:8428/-/healthy` returns OK
- [ ] Grafana (PR #104) connects successfully as Prometheus datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)