### PR TITLE
fix(deploy): remove blank line breaking SSH argument passing

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -150,7 +150,6 @@ jobs:
           -o ServerAliveInterval=30 \
           -o ServerAliveCountMax=10 \
           "${DEPLOY_USER}@${DEPLOY_HOST}" bash -s -- \
-
             "$BRANCH" \
             "$PREFERRED_DEPLOY_DIR" \
             "$LEGACY_DEPLOY_DIR" \


### PR DESCRIPTION
## Summary
- Fix deploy workflow failing with `release-0.0.2: command not found` (exit code 127)
- A blank line between `bash -s -- \` and `"$BRANCH"` broke shell line continuation, causing the branch name to be executed as a command instead of passed as an argument

## Test plan
- [ ] Push to `release-0.0.2` branch and verify deploy workflow passes the SSH step

🤖 Generated with [Claude Code](https://claude.com/claude-code)