### PR TITLE
chore: disable integration and playwright CI workflows

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -4,14 +4,17 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  merge_group:
-  pull_request:
-    branches:
-      - main
-      - "release/**"
-  push:
-    tags:
-      - "v*.*.*"
+  # Disabled: no integration secrets configured in GitHub.
+  # Re-enable by uncommenting the triggers below.
+  # merge_group:
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - "release/**"
+  # push:
+  #   tags:
+  #     - "v*.*.*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -4,17 +4,20 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  merge_group:
-  pull_request:
-    branches:
-      - main
-      - "release/**"
-  push:
-    tags:
-      - "v*.*.*"
-    # TODO: Remove this if we enable merge-queues for release branches.
-    branches:
-      - "release/**"
+  # Disabled: no integration secrets configured in GitHub.
+  # Re-enable by uncommenting the triggers below.
+  # merge_group:
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - "release/**"
+  # push:
+  #   tags:
+  #     - "v*.*.*"
+  #   # TODO: Remove this if we enable merge-queues for release branches.
+  #   branches:
+  #     - "release/**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Disables `pr-integration-tests` and `pr-playwright-tests` automatic triggers (no secrets configured)
- Both workflows now only run via manual `workflow_dispatch`
- Removes 2 heavy workflows from every PR (multiple Docker image builds + paid runners)
- Re-enable by uncommenting the triggers once secrets are set up

🤖 Generated with [Claude Code](https://claude.com/claude-code)