### PR TITLE
#108

### DIFF
--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -3,17 +3,17 @@ from datetime import datetime
 
 import jwt
 from fastapi import Depends
-from fastapi import HTTPException
 from fastapi import Request
-from fastapi import status
 
-from ee.onyx.configs.app_configs import SUPER_CLOUD_API_KEY
+from ee.onyx.configs.app_configs import PLATFORM_ADMIN_API_KEY
 from ee.onyx.configs.app_configs import SUPER_USERS
 from ee.onyx.server.seeding import get_seed_config
 from onyx.auth.users import current_admin_user
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 
@@ -37,20 +37,23 @@ def get_default_admin_user_emails_() -> list[str]:
     return []
 
 
-async def current_cloud_superuser(
+async def current_platform_admin(
     request: Request,
     user: User = Depends(current_admin_user),
 ) -> User:
-    api_key = request.headers.get("Authorization", "").replace("Bearer ", "")
-    if api_key != SUPER_CLOUD_API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid API key")
+    api_key = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    if api_key != PLATFORM_ADMIN_API_KEY:
+        raise OnyxError(OnyxErrorCode.UNAUTHENTICATED, "Invalid API key")
 
-    if user and user.email not in SUPER_USERS:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Access denied. User must be a cloud superuser to perform this action.",
+    if user and user.email.lower() not in SUPER_USERS:
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Access denied. User must be a platform admin to perform this action.",
         )
     return user
+
+
+current_cloud_superuser = current_platform_admin
 
 
 def generate_anonymous_user_jwt_token(tenant_id: str) -> str:

--- a/backend/ee/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/ee/onyx/background/celery/tasks/beat_schedule.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from typing import Any
 
 from ee.onyx.configs.app_configs import CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS
+from ee.onyx.server.control_plane import is_control_plane_configured
 from onyx.background.celery.tasks.beat_schedule import (
     beat_cloud_tasks as base_beat_system_tasks,
 )
@@ -20,36 +21,44 @@ from shared_configs.configs import MULTI_TENANT
 
 ee_beat_system_tasks: list[dict] = []
 
-ee_beat_task_templates: list[dict] = [
-    {
-        "name": "autogenerate-usage-report",
-        "task": OnyxCeleryTask.GENERATE_USAGE_REPORT_TASK,
-        "schedule": timedelta(days=30),
-        "options": {
-            "priority": OnyxCeleryPriority.MEDIUM,
-            "expires": BEAT_EXPIRES_DEFAULT,
+ee_beat_task_templates: list[dict] = []
+
+if is_control_plane_configured():
+    ee_beat_task_templates.append(
+        {
+            "name": "autogenerate-usage-report",
+            "task": OnyxCeleryTask.GENERATE_USAGE_REPORT_TASK,
+            "schedule": timedelta(days=30),
+            "options": {
+                "priority": OnyxCeleryPriority.MEDIUM,
+                "expires": BEAT_EXPIRES_DEFAULT,
+            },
+        }
+    )
+
+ee_beat_task_templates.extend(
+    [
+        {
+            "name": "check-ttl-management",
+            "task": OnyxCeleryTask.CHECK_TTL_MANAGEMENT_TASK,
+            "schedule": timedelta(hours=CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS),
+            "options": {
+                "priority": OnyxCeleryPriority.MEDIUM,
+                "expires": BEAT_EXPIRES_DEFAULT,
+            },
         },
-    },
-    {
-        "name": "check-ttl-management",
-        "task": OnyxCeleryTask.CHECK_TTL_MANAGEMENT_TASK,
-        "schedule": timedelta(hours=CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS),
-        "options": {
-            "priority": OnyxCeleryPriority.MEDIUM,
-            "expires": BEAT_EXPIRES_DEFAULT,
+        {
+            "name": "export-query-history-cleanup-task",
+            "task": OnyxCeleryTask.EXPORT_QUERY_HISTORY_CLEANUP_TASK,
+            "schedule": timedelta(hours=1),
+            "options": {
+                "priority": OnyxCeleryPriority.MEDIUM,
+                "expires": BEAT_EXPIRES_DEFAULT,
+                "queue": OnyxCeleryQueues.CSV_GENERATION,
+            },
         },
-    },
-    {
-        "name": "export-query-history-cleanup-task",
-        "task": OnyxCeleryTask.EXPORT_QUERY_HISTORY_CLEANUP_TASK,
-        "schedule": timedelta(hours=1),
-        "options": {
-            "priority": OnyxCeleryPriority.MEDIUM,
-            "expires": BEAT_EXPIRES_DEFAULT,
-            "queue": OnyxCeleryQueues.CSV_GENERATION,
-        },
-    },
-]
+    ]
+)
 
 ee_tasks_to_schedule: list[dict] = []
 

--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -114,9 +114,36 @@ STRIPE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY")
 JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 
 
-# Super Users
-SUPER_USERS = json.loads(os.environ.get("SUPER_USERS", "[]"))
-SUPER_CLOUD_API_KEY = os.environ.get("SUPER_CLOUD_API_KEY", "api_key")
+def _parse_super_users(raw_super_users: str | None) -> list[str]:
+    if not raw_super_users:
+        return []
+
+    try:
+        parsed_super_users = json.loads(raw_super_users)
+        if isinstance(parsed_super_users, list):
+            return [
+                str(email).strip().lower()
+                for email in parsed_super_users
+                if str(email).strip()
+            ]
+    except json.JSONDecodeError:
+        pass
+
+    return [
+        email.strip().lower()
+        for email in raw_super_users.split(",")
+        if email.strip()
+    ]
+
+
+# Platform Admins
+SUPER_USERS = _parse_super_users(os.environ.get("SUPER_USERS"))
+PLATFORM_ADMIN_API_KEY = os.environ.get(
+    "PLATFORM_ADMIN_API_KEY",
+    os.environ.get("SUPER_CLOUD_API_KEY", "api_key"),
+)
+# Backwards compatibility for older code/configs that still reference the old name.
+SUPER_CLOUD_API_KEY = PLATFORM_ADMIN_API_KEY
 
 POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY")
 POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"

--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -15,6 +15,7 @@ from typing import Literal
 import httpx
 
 from ee.onyx.configs.app_configs import CLOUD_DATA_PLANE_URL
+from ee.onyx.server.control_plane import is_control_plane_configured
 from ee.onyx.server.billing.models import BillingInformationResponse
 from ee.onyx.server.billing.models import CreateCheckoutSessionResponse
 from ee.onyx.server.billing.models import CreateCustomerPortalSessionResponse
@@ -31,6 +32,12 @@ logger = setup_logger()
 
 # HTTP request timeout for billing service calls
 _REQUEST_TIMEOUT = 30.0
+
+
+def _is_multi_tenant_without_control_plane() -> bool:
+    return MULTI_TENANT and not is_control_plane_configured(
+        CONTROL_PLANE_API_BASE_URL
+    )
 
 
 def _get_proxy_headers(license_data: str | None) -> dict[str, str]:
@@ -96,6 +103,13 @@ async def _make_billing_request(
     Raises:
         OnyxError: If request fails
     """
+    if _is_multi_tenant_without_control_plane():
+        if path == "/billing-information":
+            return {"subscribed": False}
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            "Billing is disabled when no control plane is configured.",
+        )
 
     base_url = _get_base_url()
     url = f"{base_url}{path}"

--- a/backend/ee/onyx/server/control_plane.py
+++ b/backend/ee/onyx/server/control_plane.py
@@ -1,0 +1,28 @@
+"""Helpers for determining whether the cloud control plane is configured."""
+
+import onyx.configs.app_configs as onyx_app_configs
+
+
+DEFAULT_CONTROL_PLANE_API_BASE_URL = "http://localhost:8082"
+
+
+def _normalize_control_plane_api_base_url(control_plane_api_base_url: str | None) -> str:
+    return (control_plane_api_base_url or "").strip().rstrip("/")
+
+
+def is_control_plane_configured(
+    control_plane_api_base_url: str | None = None,
+) -> bool:
+    """Return True only when a non-default control plane URL is configured."""
+    configured_base_url = (
+        control_plane_api_base_url
+        if control_plane_api_base_url is not None
+        else onyx_app_configs.CONTROL_PLANE_API_BASE_URL
+    )
+    normalized_base_url = _normalize_control_plane_api_base_url(configured_base_url)
+    normalized_default_base_url = _normalize_control_plane_api_base_url(
+        DEFAULT_CONTROL_PLANE_API_BASE_URL
+    )
+    return bool(normalized_base_url) and (
+        normalized_base_url != normalized_default_base_url
+    )

--- a/backend/ee/onyx/server/evals/api.py
+++ b/backend/ee/onyx/server/evals/api.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from fastapi import Depends
 
-from ee.onyx.auth.users import current_cloud_superuser
+from ee.onyx.auth.users import current_platform_admin
 from onyx.background.celery.apps.client import celery_app as client_app
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.models import User
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/evals")
 @router.post("/eval_run", response_model=EvalRunAck)
 def eval_run(
     request: EvalConfigurationOptions,
-    user: User = Depends(current_cloud_superuser),  # noqa: ARG001
+    user: User = Depends(current_platform_admin),  # noqa: ARG001
 ) -> EvalRunAck:
     """
     Run an evaluation with the given message and optional dataset.

--- a/backend/ee/onyx/server/tenant_usage_limits.py
+++ b/backend/ee/onyx/server/tenant_usage_limits.py
@@ -4,6 +4,7 @@ import time
 
 import requests
 
+from ee.onyx.server.control_plane import is_control_plane_configured
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.configs.app_configs import DEV_MODE
@@ -29,6 +30,10 @@ def fetch_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides] | None
         Dictionary mapping tenant_id to their specific limit overrides.
         Returns empty dict on any error (falls back to defaults).
     """
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        logger.info("Control plane not configured, skipping usage limit overrides")
+        return None
+
     try:
         token = generate_data_plane_token()
         headers = {
@@ -114,6 +119,8 @@ def get_tenant_usage_limit_overrides(
     """
 
     if DEV_MODE:  # in dev mode, we return unlimited limits for all tenants
+        return unlimited(tenant_id)
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
         return unlimited(tenant_id)
 
     global _tenant_usage_limit_overrides

--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from fastapi import Response
 from fastapi_users import exceptions
 
-from ee.onyx.auth.users import current_cloud_superuser
+from ee.onyx.auth.users import current_platform_admin
 from ee.onyx.server.tenants.models import ImpersonateRequest
 from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from onyx.auth.users import auth_backend
@@ -22,9 +22,9 @@ router = APIRouter(prefix="/tenants")
 @router.post("/impersonate")
 async def impersonate_user(
     impersonate_request: ImpersonateRequest,
-    _: User = Depends(current_cloud_superuser),
+    _: User = Depends(current_platform_admin),
 ) -> Response:
-    """Allows a cloud superuser to impersonate another user by generating an impersonation JWT token"""
+    """Allows a platform admin to impersonate another user."""
     try:
         tenant_id = get_tenant_id_for_email(impersonate_request.email)
     except exceptions.UserNotExists:

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -1,3 +1,4 @@
+from typing import NoReturn
 from typing import cast
 from typing import Literal
 
@@ -5,10 +6,13 @@ import requests
 import stripe
 
 from ee.onyx.configs.app_configs import STRIPE_SECRET_KEY
+from ee.onyx.server.control_plane import is_control_plane_configured
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 stripe.api_key = STRIPE_SECRET_KEY
@@ -16,11 +20,21 @@ stripe.api_key = STRIPE_SECRET_KEY
 logger = setup_logger()
 
 
+def _raise_billing_disabled_without_control_plane() -> NoReturn:
+    raise OnyxError(
+        OnyxErrorCode.NOT_IMPLEMENTED,
+        "Billing is disabled when no control plane is configured.",
+    )
+
+
 def fetch_stripe_checkout_session(
     tenant_id: str,
     billing_period: Literal["monthly", "annual"] = "monthly",
     seats: int | None = None,
 ) -> str:
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        _raise_billing_disabled_without_control_plane()
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
@@ -50,6 +64,9 @@ def fetch_stripe_checkout_session(
 
 
 def fetch_tenant_stripe_information(tenant_id: str) -> dict:
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        _raise_billing_disabled_without_control_plane()
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
@@ -65,6 +82,9 @@ def fetch_tenant_stripe_information(tenant_id: str) -> dict:
 def fetch_billing_information(
     tenant_id: str,
 ) -> BillingInformation | SubscriptionStatusResponse:
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        return SubscriptionStatusResponse(subscribed=False)
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
@@ -95,6 +115,9 @@ def fetch_customer_portal_session(tenant_id: str, return_url: str | None = None)
     NOTE: This is currently only used for multi-tenant (cloud) deployments.
     Self-hosted proxy endpoints will be added in a future phase.
     """
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        _raise_billing_disabled_without_control_plane()
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ee.onyx.configs.app_configs import HUBSPOT_TRACKING_URL
+from ee.onyx.server.control_plane import is_control_plane_configured
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.server.tenants.models import TenantByDomainResponse
 from ee.onyx.server.tenants.models import TenantCreationPayload
@@ -184,6 +185,10 @@ async def provision_tenant(tenant_id: str, email: str) -> None:
 async def notify_control_plane(
     tenant_id: str, email: str, referral_source: str | None = None
 ) -> None:
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        logger.info("Control plane not configured, skipping tenant creation sync")
+        return
+
     logger.info("Fetching billing information")
     token = generate_data_plane_token()
     headers = {
@@ -534,6 +539,10 @@ async def submit_to_hubspot(
 
 
 async def delete_user_from_control_plane(tenant_id: str, email: str) -> None:
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        logger.info("Control plane not configured, skipping tenant deletion sync")
+        return
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
@@ -568,6 +577,10 @@ def get_tenant_by_domain_from_control_plane(
     Returns:
         A dictionary containing tenant information if found, None otherwise
     """
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
+        logger.info("Control plane not configured, skipping tenant domain lookup")
+        return None
+
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",

--- a/backend/ee/onyx/server/usage_limits.py
+++ b/backend/ee/onyx/server/usage_limits.py
@@ -1,8 +1,10 @@
 """EE Usage limits - trial detection via billing information."""
 
+from ee.onyx.server.control_plane import is_control_plane_configured
 from ee.onyx.server.tenants.billing import fetch_billing_information
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
+from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
@@ -17,6 +19,8 @@ def is_tenant_on_trial(tenant_id: str) -> bool:
     to determine if the tenant has an active trial.
     """
     if not MULTI_TENANT:
+        return False
+    if not is_control_plane_configured(CONTROL_PLANE_API_BASE_URL):
         return False
 
     try:

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -103,8 +103,8 @@ def check_router_auth(
     control_plane_dep = fetch_ee_implementation_or_noop(
         "onyx.server.tenants.access", "control_plane_dep"
     )
-    current_cloud_superuser = fetch_ee_implementation_or_noop(
-        "onyx.auth.users", "current_cloud_superuser"
+    current_platform_admin = fetch_ee_implementation_or_noop(
+        "onyx.auth.users", "current_platform_admin"
     )
     verify_scim_token = fetch_ee_implementation_or_noop(
         "onyx.server.scim.auth", "verify_scim_token"
@@ -132,7 +132,7 @@ def check_router_auth(
                     or depends_fn == current_chat_accessible_user
                     or depends_fn == current_user_from_websocket
                     or depends_fn == control_plane_dep
-                    or depends_fn == current_cloud_superuser
+                    or depends_fn == current_platform_admin
                     or depends_fn == verify_scim_token
                 ):
                     found_auth = True

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -230,13 +230,21 @@ SKIP_USERFILE_THRESHOLD_TENANT_LIST = (
 #####
 # Usage Limits Configuration (meant for cloud, off by default for self-hosted)
 #####
-# Whether usage limits are enforced (defaults to MULTI_TENANT value)
+# Whether usage limits are enforced.
+# By default, this is only enabled when running multi-tenant with a non-default
+# control plane configured. Self-hosted multi-tenant deployments should not
+# implicitly enable usage limits.
 _USAGE_LIMITS_ENABLED_RAW = os.environ.get("USAGE_LIMITS_ENABLED")
+_CONTROL_PLANE_API_BASE_URL = (
+    os.environ.get("CONTROL_PLANE_API_BASE_URL", "http://localhost:8082") or ""
+).strip().rstrip("/")
+_CONTROL_PLANE_CONFIGURED = bool(_CONTROL_PLANE_API_BASE_URL) and (
+    _CONTROL_PLANE_API_BASE_URL != "http://localhost:8082"
+)
 if _USAGE_LIMITS_ENABLED_RAW is not None:
     USAGE_LIMITS_ENABLED = _USAGE_LIMITS_ENABLED_RAW.lower() == "true"
 else:
-    # Default: enabled on cloud (MULTI_TENANT), disabled for self-hosted
-    USAGE_LIMITS_ENABLED = MULTI_TENANT
+    USAGE_LIMITS_ENABLED = MULTI_TENANT and _CONTROL_PLANE_CONFIGURED
 
 # Usage limit window in seconds (default: 1 week = 604800 seconds)
 USAGE_LIMIT_WINDOW_SECONDS = int(os.environ.get("USAGE_LIMIT_WINDOW_SECONDS", "604800"))

--- a/backend/tests/unit/ee/onyx/auth/test_users.py
+++ b/backend/tests/unit/ee/onyx/auth/test_users.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Request
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+def _make_request(api_key: str) -> Request:
+    scope = {
+        "type": "http",
+        "headers": [
+            (b"authorization", f"Bearer {api_key}".encode()),
+        ],
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_current_platform_admin_allows_super_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ee.onyx.auth.users import current_platform_admin
+
+    monkeypatch.setattr("ee.onyx.auth.users.PLATFORM_ADMIN_API_KEY", "platform-key")
+    monkeypatch.setattr("ee.onyx.auth.users.SUPER_USERS", ["admin@example.com"])
+
+    user = MagicMock()
+    user.email = "admin@example.com"
+
+    result = await current_platform_admin(_make_request("platform-key"), user=user)
+
+    assert result is user
+
+
+def test_parse_super_users_supports_comma_separated_env() -> None:
+    from ee.onyx.configs.app_configs import _parse_super_users
+
+    assert _parse_super_users("Admin@Example.com, second@example.com ") == [
+        "admin@example.com",
+        "second@example.com",
+    ]
+
+
+def test_parse_super_users_supports_legacy_json_list() -> None:
+    from ee.onyx.configs.app_configs import _parse_super_users
+
+    assert _parse_super_users('["Admin@Example.com", "second@example.com"]') == [
+        "admin@example.com",
+        "second@example.com",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_current_platform_admin_rejects_invalid_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ee.onyx.auth.users import current_platform_admin
+
+    monkeypatch.setattr("ee.onyx.auth.users.PLATFORM_ADMIN_API_KEY", "platform-key")
+    monkeypatch.setattr("ee.onyx.auth.users.SUPER_USERS", ["admin@example.com"])
+
+    user = MagicMock()
+    user.email = "admin@example.com"
+
+    with pytest.raises(OnyxError) as exc_info:
+        await current_platform_admin(_make_request("wrong-key"), user=user)
+
+    assert exc_info.value.error_code is OnyxErrorCode.UNAUTHENTICATED
+
+
+@pytest.mark.asyncio
+async def test_current_platform_admin_rejects_non_super_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ee.onyx.auth.users import current_platform_admin
+
+    monkeypatch.setattr("ee.onyx.auth.users.PLATFORM_ADMIN_API_KEY", "platform-key")
+    monkeypatch.setattr("ee.onyx.auth.users.SUPER_USERS", ["admin@example.com"])
+
+    user = MagicMock()
+    user.email = "member@example.com"
+
+    with pytest.raises(OnyxError) as exc_info:
+        await current_platform_admin(_make_request("platform-key"), user=user)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
@@ -251,6 +251,21 @@ class TestGetBillingInformation:
         assert isinstance(result, SubscriptionStatusResponse)
         assert result.subscribed is False
 
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.service.MULTI_TENANT", True)
+    @patch("ee.onyx.server.billing.service.is_control_plane_configured", return_value=False)
+    async def test_returns_not_subscribed_without_control_plane(
+        self,
+        mock_control_plane: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """Multi-tenant self-hosted should not require control plane for reads."""
+        from ee.onyx.server.billing.service import get_billing_information
+
+        result = await get_billing_information(tenant_id="tenant_123")
+
+        assert isinstance(result, SubscriptionStatusResponse)
+        assert result.subscribed is False
+
 
 class TestUpdateSeatCount:
     """Tests for update_seat_count service function."""
@@ -307,3 +322,21 @@ class TestUpdateSeatCount:
 
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["body"]["tenant_id"] == "tenant_123"
+
+
+class TestControlPlaneDisabledBilling:
+    """Tests for self-hosted multi-tenant deployments without control plane."""
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.service.MULTI_TENANT", True)
+    @patch("ee.onyx.server.billing.service.is_control_plane_configured", return_value=False)
+    async def test_create_checkout_session_raises_when_control_plane_missing(
+        self,
+        mock_control_plane: MagicMock,  # noqa: ARG002
+    ) -> None:
+        from ee.onyx.server.billing.service import create_checkout_session
+
+        with pytest.raises(OnyxError) as exc_info:
+            await create_checkout_session(tenant_id="tenant_123")
+
+        assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -54,6 +54,12 @@ GRAFANA_ALERT_EMAILS=alerts@example.com
 # SAML config directory for OneLogin compatible setups
 #SAML_CONF_DIR=
 
+## Self-hosted multi-tenant should keep usage limits off unless you wire in a control plane.
+USAGE_LIMITS_ENABLED=false
+## Platform admin emails for company-management endpoints (comma-separated).
+#SUPER_USERS=admin@example.com
+## Shared API key for platform admin-protected endpoints.
+#PLATFORM_ADMIN_API_KEY=
 
 # How long before user needs to reauthenticate, default to 7 days. (cookie expiration time)
 SESSION_EXPIRE_TIME_SECONDS=604800

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -41,6 +41,12 @@ USER_AUTH_SECRET=""
 
 ## Enterprise Features, requires a paid plan and licenses
 ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false
+## Self-hosted multi-tenant should keep usage limits off unless you wire in a control plane.
+USAGE_LIMITS_ENABLED=false
+## Platform admin emails for company-management endpoints (comma-separated).
+# SUPER_USERS=admin@example.com
+## Shared API key for platform admin-protected endpoints.
+# PLATFORM_ADMIN_API_KEY=
 
 ## User File Upload Configuration
 # Skip the token count threshold check (100,000 tokens) for uploaded files


### PR DESCRIPTION
Este PR desacopla la primera fase de multi-tenancy self-hosted del control plane para que no dependa de `http://localhost:8082` ni de servicios cloud cuando no estén configurados.

Cambios principales:
- Agregué un helper central para detectar si el control plane está realmente configurado.
- En `backend/ee/onyx/server/tenants/provisioning.py`, las llamadas a control plane (`notify_control_plane`, `get_tenant_by_domain_from_control_plane`, `delete_user_from_control_plane`) ahora hacen `no-op` o devuelven `None` cuando no hay control plane configurado.
- En billing/usage limits, protegí todas las rutas y helpers que antes llamaban siempre al control plane:
  - `is_tenant_on_trial()` ahora devuelve `False` sin control plane.
  - `USAGE_LIMITS_ENABLED` ya no depende solo de `MULTI_TENANT`; por default queda desactivado si no hay un control plane real configurado.
  - Los overrides de usage limits también se saltan en self-hosted sin control plane.
  - El beat task `autogenerate-usage-report` solo se agenda si hay control plane configurado.
  - Las lecturas de billing devuelven estado neutral (`subscribed=false`) y las acciones de Stripe quedan explícitamente bloqueadas para no intentar hablar con un control plane inexistente.
- Renombré el concepto de `current_cloud_superuser` a `current_platform_admin`, manteniendo compatibilidad hacia atrás con alias para no romper referencias existentes.
- Mantuvimos `SUPER_USERS`, pero ahora soporta formato comma-separated además del formato legacy JSON.
- Agregué `PLATFORM_ADMIN_API_KEY` como nombre nuevo, con fallback a `SUPER_CLOUD_API_KEY` para no romper despliegues actuales.
- Actualicé los templates de env para dejar `USAGE_LIMITS_ENABLED=false` y documentar `SUPER_USERS` / `PLATFORM_ADMIN_API_KEY`.

Seguridad / impacto:
- El cambio está hecho para degradar en forma segura: si no hay control plane, el sistema deja de intentar llamadas externas en vez de fallar contra `localhost:8082`.
- No cambia el flujo normal cuando sí existe un control plane configurado.

Validación:
- Corrí `py_compile` sobre todos los archivos tocados y quedó OK.
- También agregué tests unitarios para platform admin y billing sin control plane.
- No pude ejecutar `pytest` en esta máquina porque no había runner/venv disponible en el entorno actual.
