### PR TITLE
#109

### DIFF
--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -25,7 +25,6 @@ from onyx.auth.users import exceptions
 from onyx.configs.app_configs import ANTHROPIC_DEFAULT_API_KEY
 from onyx.configs.app_configs import COHERE_DEFAULT_API_KEY
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
-from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.app_configs import OPENAI_DEFAULT_API_KEY
 from onyx.configs.app_configs import OPENROUTER_DEFAULT_API_KEY
 from onyx.configs.app_configs import VERTEXAI_DEFAULT_CREDENTIALS
@@ -41,6 +40,8 @@ from onyx.db.models import AvailableTenant
 from onyx.db.models import IndexModelStatus
 from onyx.db.models import SearchSettings
 from onyx.db.models import UserTenantMapping
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.llm.well_known_providers.constants import ANTHROPIC_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
@@ -57,6 +58,8 @@ from onyx.llm.well_known_providers.llm_provider_options import (
 from onyx.server.manage.embedding.models import CloudEmbeddingProviderCreationRequest
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.settings.store import load_settings
+from onyx.server.settings.store import store_settings
 from onyx.setup import setup_onyx
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -75,52 +78,29 @@ async def get_or_provision_tenant(
     request: Request | None = None,
 ) -> str:
     """
-    Get existing tenant ID for an email or create a new tenant if none exists.
-    This function should only be called after we have verified we want this user's tenant to exist.
-    It returns the tenant ID associated with the email, creating a new tenant if necessary.
+    Resolve the tenant mapping for an email.
+
+    Self-hosted multi-tenant deployments do not auto-create or auto-assign
+    tenants during auth flows anymore. Users must already have a
+    UserTenantMapping, typically created by an invitation or by an explicit
+    company-creation flow.
     """
-    # Early return for non-multi-tenant mode
     if not MULTI_TENANT:
         return POSTGRES_DEFAULT_SCHEMA
+
+    try:
+        tenant_id = get_tenant_id_for_email(email)
+    except exceptions.UserNotExists:
+        logger.warning("Rejected tenant resolution for unmapped email %s", email)
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "This account has not been invited to a company yet.",
+        )
 
     if referral_source and request:
         await submit_to_hubspot(email, referral_source, request)
 
-    # First, check if the user already has a tenant
-    tenant_id: str | None = None
-    try:
-        tenant_id = get_tenant_id_for_email(email)
-        return tenant_id
-    except exceptions.UserNotExists:
-        # User doesn't exist, so we need to create a new tenant or assign an existing one
-        pass
-
-    try:
-        # Try to get a pre-provisioned tenant
-        tenant_id = await get_available_tenant()
-
-        if tenant_id:
-            # If we have a pre-provisioned tenant, assign it to the user
-            await assign_tenant_to_user(tenant_id, email, referral_source)
-            logger.info(f"Assigned pre-provisioned tenant {tenant_id} to user {email}")
-        else:
-            # If no pre-provisioned tenant is available, create a new one on-demand
-            tenant_id = await create_tenant(email, referral_source)
-
-        # Notify control plane if we have created / assigned a new tenant
-        if not DEV_MODE:
-            await notify_control_plane(tenant_id, email, referral_source)
-
-        return tenant_id
-
-    except Exception as e:
-        # If we've encountered an error, log and raise an exception
-        error_msg = "Failed to provision tenant"
-        logger.error(error_msg, exc_info=e)
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to provision tenant. Please try again later.",
-        )
+    return tenant_id
 
 
 async def create_tenant(
@@ -681,6 +661,11 @@ async def setup_tenant(tenant_id: str) -> None:
                 and current_search_settings.provider_type == EmbeddingProvider.COHERE
             )
             setup_onyx(db_session, tenant_id, cohere_enabled=cohere_enabled)
+
+            settings = load_settings()
+            if not settings.invite_only_enabled:
+                settings.invite_only_enabled = True
+                store_settings(settings)
 
     except Exception as e:
         logger.exception(f"Failed to set up tenant {tenant_id}")

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -459,8 +459,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             async with get_async_session_context_manager(tenant_id) as db_session:
                 # Check invite list based on deployment mode
                 if MULTI_TENANT:
-                    # Multi-tenant: Only require invite for existing tenants
-                    # New tenant creation (first user) doesn't require an invite
+                    # Multi-tenant: the first user for a mapped tenant can finish
+                    # registration without the invite-only list, but any existing
+                    # tenant with users must still enforce invites for new signups.
                     user_count = await get_user_count()
                     if user_count > 0:
                         # Tenant already has users - require invite for new users
@@ -782,31 +783,50 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         request: Optional[Request] = None,
         response: Optional[Response] = None,
     ) -> None:
-        try:
-            if response and request:
-                for cookie_name in (
-                    ANONYMOUS_USER_COOKIE_NAME,
-                    LEGACY_ANONYMOUS_USER_COOKIE_NAME,
-                ):
-                    if cookie_name not in request.cookies:
-                        continue
-
-                    response.delete_cookie(
-                        cookie_name,
-                        # Ensure cookie deletion doesn't override other cookies by setting the same path/domain
-                        path="/",
-                        domain=None,
-                        secure=WEB_DOMAIN.startswith("https"),
-                    )
-                logger.debug(f"Deleted anonymous user cookie for user {user.email}")
-        except Exception:
-            logger.exception("Error deleting anonymous user cookie")
-
+        tenant_token = None
         tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
-        mt_cloud_identify(
-            distinct_id=str(user.id),
-            properties={"email": user.email, "tenant_id": tenant_id},
-        )
+
+        if AUTH_TYPE == AuthType.BASIC:
+            tenant_id = await fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.provisioning",
+                "get_or_provision_tenant",
+                async_return_default_schema,
+            )(
+                email=user.email,
+                request=request,
+            )
+            tenant_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+
+        try:
+            try:
+                if response and request:
+                    for cookie_name in (
+                        ANONYMOUS_USER_COOKIE_NAME,
+                        LEGACY_ANONYMOUS_USER_COOKIE_NAME,
+                    ):
+                        if cookie_name not in request.cookies:
+                            continue
+
+                        response.delete_cookie(
+                            cookie_name,
+                            # Ensure cookie deletion doesn't override other cookies by setting the same path/domain
+                            path="/",
+                            domain=None,
+                            secure=WEB_DOMAIN.startswith("https"),
+                        )
+                    logger.debug(
+                        f"Deleted anonymous user cookie for user {user.email}"
+                    )
+            except Exception:
+                logger.exception("Error deleting anonymous user cookie")
+
+            mt_cloud_identify(
+                distinct_id=str(user.id),
+                properties={"email": user.email, "tenant_id": tenant_id},
+            )
+        finally:
+            if tenant_token is not None:
+                CURRENT_TENANT_ID_CONTEXTVAR.reset(tenant_token)
 
     async def on_after_register(
         self, user: User, request: Optional[Request] = None

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from starlette.requests import Request
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.middleware.tenant_tracking.is_valid_schema_name", return_value=True)
+@patch(
+    "ee.onyx.server.middleware.tenant_tracking.retrieve_auth_token_data_from_redis",
+    new_callable=AsyncMock,
+)
+@patch(
+    "ee.onyx.server.middleware.tenant_tracking.extract_tenant_from_auth_header",
+    return_value=None,
+)
+async def test_get_tenant_id_from_request_reads_redis_session_payload(
+    _mock_extract_tenant: MagicMock,
+    mock_retrieve_auth_token_data: AsyncMock,
+    _mock_is_valid_schema_name: MagicMock,
+) -> None:
+    from ee.onyx.server.middleware.tenant_tracking import _get_tenant_id_from_request
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/me",
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+    logger = MagicMock()
+    mock_retrieve_auth_token_data.return_value = {
+        "sub": "user-123",
+        "tenant_id": "tenant_123",
+    }
+
+    tenant_id = await _get_tenant_id_from_request(request, logger)
+
+    assert tenant_id == "tenant_123"

--- a/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth.users import exceptions
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+class _SessionContextManager:
+    def __init__(self, session: MagicMock) -> None:
+        self._session = session
+
+    def __enter__(self) -> MagicMock:
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
+class _FakeEventLoop:
+    def __init__(self) -> None:
+        self.run_in_executor = AsyncMock(return_value=None)
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.tenants.provisioning.MULTI_TENANT", True)
+@patch("ee.onyx.server.tenants.provisioning.notify_control_plane", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.create_tenant", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.get_available_tenant", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.submit_to_hubspot", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.get_tenant_id_for_email")
+async def test_get_or_provision_tenant_returns_existing_mapping(
+    mock_get_tenant_id: MagicMock,
+    mock_submit_to_hubspot: AsyncMock,
+    mock_get_available_tenant: AsyncMock,
+    mock_create_tenant: AsyncMock,
+    mock_notify_control_plane: AsyncMock,
+) -> None:
+    from ee.onyx.server.tenants.provisioning import get_or_provision_tenant
+
+    request = MagicMock()
+    mock_get_tenant_id.return_value = "tenant_123"
+
+    tenant_id = await get_or_provision_tenant(
+        "member@example.com",
+        referral_source="invite",
+        request=request,
+    )
+
+    assert tenant_id == "tenant_123"
+    mock_submit_to_hubspot.assert_awaited_once_with(
+        "member@example.com", "invite", request
+    )
+    mock_get_available_tenant.assert_not_called()
+    mock_create_tenant.assert_not_called()
+    mock_notify_control_plane.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.tenants.provisioning.MULTI_TENANT", True)
+@patch("ee.onyx.server.tenants.provisioning.notify_control_plane", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.create_tenant", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.get_available_tenant", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.submit_to_hubspot", new_callable=AsyncMock)
+@patch("ee.onyx.server.tenants.provisioning.get_tenant_id_for_email")
+async def test_get_or_provision_tenant_rejects_unknown_email_without_mapping(
+    mock_get_tenant_id: MagicMock,
+    mock_submit_to_hubspot: AsyncMock,
+    mock_get_available_tenant: AsyncMock,
+    mock_create_tenant: AsyncMock,
+    mock_notify_control_plane: AsyncMock,
+) -> None:
+    from ee.onyx.server.tenants.provisioning import get_or_provision_tenant
+
+    mock_get_tenant_id.side_effect = exceptions.UserNotExists()
+
+    with pytest.raises(OnyxError) as exc_info:
+        await get_or_provision_tenant("member@example.com")
+
+    assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    mock_submit_to_hubspot.assert_not_called()
+    mock_get_available_tenant.assert_not_called()
+    mock_create_tenant.assert_not_called()
+    mock_notify_control_plane.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.tenants.provisioning.store_settings")
+@patch("ee.onyx.server.tenants.provisioning.load_settings")
+@patch("ee.onyx.server.tenants.provisioning.setup_onyx")
+@patch("ee.onyx.server.tenants.provisioning.configure_default_api_keys")
+@patch("ee.onyx.server.tenants.provisioning.get_session_with_tenant")
+@patch("ee.onyx.server.tenants.provisioning.asyncio.get_event_loop")
+@patch("ee.onyx.server.tenants.provisioning.CURRENT_TENANT_ID_CONTEXTVAR")
+async def test_setup_tenant_enables_invite_only_for_new_tenants(
+    mock_context_var: MagicMock,
+    mock_get_event_loop: MagicMock,
+    mock_get_session_with_tenant: MagicMock,
+    mock_configure_default_api_keys: MagicMock,
+    mock_setup_onyx: MagicMock,
+    mock_load_settings: MagicMock,
+    mock_store_settings: MagicMock,
+) -> None:
+    from ee.onyx.server.tenants.provisioning import setup_tenant
+
+    fake_loop = _FakeEventLoop()
+    mock_get_event_loop.return_value = fake_loop
+    mock_context_var.set.return_value = "tenant-token"
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter_by.return_value.first.return_value = None
+    mock_get_session_with_tenant.return_value = _SessionContextManager(db_session)
+
+    settings = SimpleNamespace(invite_only_enabled=False)
+    mock_load_settings.return_value = settings
+
+    await setup_tenant("tenant_123")
+
+    mock_configure_default_api_keys.assert_called_once_with(db_session)
+    mock_setup_onyx.assert_called_once_with(
+        db_session, "tenant_123", cohere_enabled=False
+    )
+    assert settings.invite_only_enabled is True
+    mock_store_settings.assert_called_once_with(settings)
+    mock_context_var.reset.assert_called_once_with("tenant-token")

--- a/backend/tests/unit/onyx/auth/test_tenant_resolution.py
+++ b/backend/tests/unit/onyx/auth/test_tenant_resolution.py
@@ -1,0 +1,86 @@
+import json
+import uuid
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_on_after_login_resolves_tenant_for_basic_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import onyx.auth.users as users_module
+
+    resolver = AsyncMock(return_value="tenant_123")
+    monkeypatch.setattr(users_module, "AUTH_TYPE", users_module.AuthType.BASIC)
+    monkeypatch.setattr(
+        users_module,
+        "fetch_ee_implementation_or_noop",
+        lambda *args, **kwargs: resolver,  # noqa: ARG005
+    )
+
+    context_var = MagicMock()
+    context_var.get.return_value = "stale-tenant"
+    context_var.set.return_value = "tenant-token"
+    monkeypatch.setattr(users_module, "CURRENT_TENANT_ID_CONTEXTVAR", context_var)
+
+    identify = MagicMock()
+    monkeypatch.setattr(users_module, "mt_cloud_identify", identify)
+
+    user_manager = users_module.UserManager(MagicMock())
+    user = MagicMock()
+    user.id = "user-123"
+    user.email = "member@example.com"
+
+    await user_manager.on_after_login(user)
+
+    resolver.assert_awaited_once_with(email="member@example.com", request=None)
+    context_var.set.assert_called_once_with("tenant_123")
+    context_var.reset.assert_called_once_with("tenant-token")
+    identify.assert_called_once_with(
+        distinct_id="user-123",
+        properties={"email": "member@example.com", "tenant_id": "tenant_123"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_tenant_aware_redis_strategy_writes_tenant_id_into_session_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import onyx.auth.users as users_module
+
+    redis = MagicMock()
+    redis.set = AsyncMock()
+    monkeypatch.setattr(
+        users_module,
+        "get_async_redis_connection",
+        AsyncMock(return_value=redis),
+    )
+
+    resolver = AsyncMock(return_value="tenant_abc")
+    monkeypatch.setattr(
+        users_module,
+        "fetch_ee_implementation_or_noop",
+        lambda *args, **kwargs: resolver,  # noqa: ARG005
+    )
+
+    strategy = users_module.TenantAwareRedisStrategy(
+        lifetime_seconds=120,
+        key_prefix="auth:",
+    )
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "member@example.com"
+
+    token = await strategy.write_token(user)
+
+    resolver.assert_awaited_once_with(email="member@example.com")
+    redis.set.assert_awaited_once()
+    redis_key, payload = redis.set.await_args.args
+    assert redis_key == f"auth:{token}"
+    assert json.loads(payload) == {
+        "sub": str(user.id),
+        "tenant_id": "tenant_abc",
+    }
+    assert redis.set.await_args.kwargs["ex"] == 120


### PR DESCRIPTION
Este PR implementa la Fase 2 para que `AUTH_TYPE=basic` resuelva correctamente el tenant en multi-tenant self-hosted y para que el acceso ya no auto-provisione tenants para correos no invitados.

Cambios principales:
- En `backend/onyx/auth/users.py` reforcé el flujo de login para `basic auth`:
  - `on_after_login()` ahora vuelve a resolver el tenant del usuario y fija el `tenant_id` correcto en contexto antes de telemetría.
  - La sesión Redis sigue guardando `tenant_id` en el payload del token mediante `TenantAwareRedisStrategy.write_token()`, que es lo que después consume el middleware.
- En `backend/ee/onyx/server/tenants/provisioning.py` cambié `get_or_provision_tenant()` para que en multi-tenant self-hosted:
  - resuelva únicamente mappings existentes;
  - rechace correos sin `UserTenantMapping`;
  - deje de auto-asignar tenants preprovisionados o crear tenants nuevos durante login/registro.
- Esto hace que registro/login queden alineados con el modelo de invitaciones: solo entra quien ya fue asociado a una empresa por mapping previo.
- En `setup_tenant()` dejé `invite_only_enabled=True` por default para tenants nuevos, como base segura para la siguiente fase de company creation.

Sobre el middleware:
- No hice cambios en `backend/ee/onyx/server/middleware/tenant_tracking.py` porque ya era agnóstico al tipo de auth.
- Verifiqué el flujo end-to-end a nivel de código: login -> Redis guarda `tenant_id` -> middleware lee `tenant_id` desde la sesión.

Impacto funcional:
- Usuarios sin mapping ya no disparan creación/asignación implícita de tenant.
- Usuarios invitados o ya asociados a un tenant siguen resolviendo contexto correctamente.
- El tenant context para `basic auth` queda disponible de forma consistente en requests subsecuentes.

Validación:
- Agregué tests unitarios para:
  - rechazo de emails sin mapping;
  - activación de `invite_only_enabled` en tenants nuevos;
  - lectura de `tenant_id` desde la sesión Redis en el middleware;
  - resolución de tenant en `on_after_login()` y escritura de `tenant_id` en Redis.
- `python -m py_compile` pasó sobre todos los archivos tocados.
- No pude correr `pytest` en este entorno porque `pytest` no está instalado actualmente.
