### PR TITLE
#111

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -23,7 +23,7 @@ services:
     - VESPA_HOST=index
     - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
     - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:?OPENSEARCH_ADMIN_PASSWORD not set}
-    - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${OPENSEARCH_FOR_ONYX_ENABLED:-true}
+    - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:-false}
     - REDIS_HOST=cache
     - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
     - CODE_INTERPRETER_BASE_URL=${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
@@ -74,7 +74,7 @@ services:
       - VESPA_HOST=index
       - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
       - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${OPENSEARCH_FOR_ONYX_ENABLED:-true}
+      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:-false}
       - REDIS_HOST=cache
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
@@ -261,15 +261,9 @@ services:
   opensearch:
     image: opensearchproject/opensearch:3.4.0
     restart: unless-stopped
-    # Controls whether this service runs. In order to enable it, add
-    # opensearch-enabled to COMPOSE_PROFILES in the environment for this
-    # docker-compose.
-    # NOTE: Now enabled on by default. To explicitly disable this service,
-    # uncomment this profile and ensure COMPOSE_PROFILES in your env does not
-    # list the profile, or when running docker compose, include all desired
-    # service names but this one. Additionally set
-    # OPENSEARCH_FOR_ONYX_ENABLED=false in your env.
-    # profiles: ["opensearch-enabled"]
+    # Multi-tenant production should not start OpenSearch by default.
+    # If you ever need it for a non-default deployment, gate it behind a profile.
+    profiles: ["opensearch-enabled"]
     environment:
       # We need discovery.type=single-node so that OpenSearch doesn't try
       # forming a cluster and waiting for other nodes to become live.

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       - VESPA_HOST=index
       - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
       - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123}
-      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${OPENSEARCH_FOR_ONYX_ENABLED:-true}
+      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:-false}
       - REDIS_HOST=cache
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       - CODE_INTERPRETER_BASE_URL=${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
@@ -95,7 +95,7 @@ services:
       - VESPA_HOST=index
       - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
       - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123}
-      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${OPENSEARCH_FOR_ONYX_ENABLED:-true}
+      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=${ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:-false}
       - REDIS_HOST=cache
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
@@ -341,8 +341,8 @@ services:
         reservations:
           cpus: '2.0'
           memory: 2G
-    # To enable OpenSearch, add opensearch-enabled to COMPOSE_PROFILES
-    # and set OPENSEARCH_FOR_ONYX_ENABLED=true in .env
+    # Multi-tenant production should leave this profile disabled and rely on Vespa.
+    # Only enable OpenSearch intentionally for non-default deployments.
     profiles: ["opensearch-enabled"]
     environment:
       # We need discovery.type=single-node so that OpenSearch doesn't try

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -104,6 +104,9 @@ SHOW_EXTRA_CONNECTORS=False
 # User File Upload Configuration
 # Skip the token count threshold check (100,000 tokens) for uploaded files
 # For self-hosted: set to true to skip for all users
+# Multi-tenant self-hosted search should rely on Vespa.
+ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false
+# Do not add `opensearch-enabled` to COMPOSE_PROFILES in production unless you explicitly want OpenSearch.
 #SKIP_USERFILE_THRESHOLD=false
 # For multi-tenant: comma-separated list of tenant IDs to skip threshold
 #SKIP_USERFILE_THRESHOLD_TENANT_IDS=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -80,8 +80,9 @@ POSTGRES_PASSWORD=
 ## remove s3-filestore from COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres.
 COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
-## Setting for enabling OpenSearch.
-OPENSEARCH_FOR_ONYX_ENABLED=true
+## Multi-tenant self-hosted should rely on Vespa and keep OpenSearch indexing off.
+ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false
+## Leave COMPOSE_PROFILES without `opensearch-enabled` so the OpenSearch container does not start.
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
 S3_ENDPOINT_URL=http://minio:9000


### PR DESCRIPTION
n [docker-compose.prod.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [docker-compose.prod-no-letsencrypt.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) dejé ENABLE_OPENSEARCH_INDEXING_FOR_ONYX en false por default para api_server y background. También dejé explícito que OpenSearch debe seguir apagado por profile en multi-tenant en [docker-compose.prod.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [docker-compose.prod-no-letsencrypt.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/). No borré el servicio opensearch porque ya estaba bien aislado detrás de profiles: ["opensearch-enabled"], que es la forma más segura de no arrancarlo sin romper el compose.

También actualicé los templates de entorno para que el valor correcto quede documentado en [env.template](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [env.prod.template](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/). El nombre que ahora manda en producción es ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false, y además dejé aclarado que no se debe agregar opensearch-enabled a COMPOSE_PROFILES en MT.

Verificación:

docker-compose -f deployment/docker_compose/docker-compose.prod.yml --env-file deployment/docker_compose/env.prod.template config pasó.
No hay migraciones ni cambios de base para este issue.
No quedó ningún archivo temporal; el .env.nginx de prueba se creó y borró en la misma validación.
Para deploy:

No correr migraciones.
Sí actualizar el .env real con ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false.
Sí asegurarse de no incluir opensearch-enabled en COMPOSE_PROFILES.
Sí redeployar api_server y background para que tomen el flag nuevo.
opensearch no debería arrancarse en este despliegue multi-tenant.
