### PR TITLE
#6

### DIFF
--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -100,7 +100,7 @@ fi
 
 # Start the Code Interpreter container
 echo "Starting Code Interpreter container..."
-docker run --detach --name onyx_code_interpreter --publish 8000:8000 --user root -v /var/run/docker.sock:/var/run/docker.sock onyxdotapp/code-interpreter:latest bash ./entrypoint.sh code-interpreter-api
+docker run --detach --name onyx_code_interpreter --publish 8000:8000 --privileged onyxdotapp/code-interpreter:latest bash ./entrypoint.sh code-interpreter-api
 
 # Ensure alembic runs in the correct directory (backend/)
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -554,13 +554,14 @@ services:
       - path: .env
         required: false
 
-    # Below is needed for the `docker-out-of-docker` execution mode
-    user: root
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    # Use Docker-in-Docker by default so untrusted executions do not receive
+    # access to the host Docker daemon.
+    privileged: true
 
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
+    # Only use host Docker socket access in explicitly trusted environments.
+    # user: root
+    # volumes:
+    #   - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   db_volume:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -366,13 +366,14 @@ services:
       - path: .env
         required: false
 
-    # Below is needed for the `docker-out-of-docker` execution mode
-    user: root
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    # Use Docker-in-Docker by default so untrusted executions do not receive
+    # access to the host Docker daemon.
+    privileged: true
 
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
+    # Only use host Docker socket access in explicitly trusted environments.
+    # user: root
+    # volumes:
+    #   - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   db_volume:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -689,13 +689,14 @@ services:
       - path: .env
         required: false
 
-    # Below is needed for the `docker-out-of-docker` execution mode
-    user: root
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    # Use Docker-in-Docker by default so untrusted executions do not receive
+    # access to the host Docker daemon.
+    privileged: true
 
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
+    # Only use host Docker socket access in explicitly trusted environments.
+    # user: root
+    # volumes:
+    #   - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   db_volume:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -640,14 +640,15 @@ services:
       - path: .env
         required: false
 
-    # Below is needed for the `docker-out-of-docker` execution mode
-    # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock
-    user: root
-    volumes:
-      - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
+    # Use Docker-in-Docker by default so untrusted executions do not receive
+    # access to the host Docker daemon.
+    privileged: true
 
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
+    # Only use host Docker socket access in explicitly trusted environments.
+    # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock
+    # user: root
+    # volumes:
+    #   - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
 
   # PRODUCTION: Uncomment the following certbot service for SSL certificate management
   # certbot:


### PR DESCRIPTION
Arreglé el issue cambiando code-interpreter a Docker-in-Docker por defecto en [docker-compose.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/), [docker-compose.prod.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/), [docker-compose.prod-no-letsencrypt.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [docker-compose.multitenant-dev.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/). Ya no se monta /var/run/docker.sock del host ni se fuerza user: root; ahora el servicio usa privileged: true, y el modo viejo quedó solo como comentario para entornos explícitamente confiables.

También actualicé el arranque manual en [restart_containers.sh](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) para quitar --user root -v /var/run/docker.sock:/var/run/docker.sock y usar --privileged.

Verificación: los 4 compose pasaron docker-compose ... config --no-env-resolution --no-interpolate -q.
