### PR TITLE
#11

### DIFF
--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -35,6 +35,8 @@ server {
 
     # Match both /api/* and /openapi.json in a single rule
     location ~ ^/(api|openapi.json)(/.*)?$ {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # Rewrite /api prefixed matched paths
         rewrite ^/api(/.*)$ $1 break;
 
@@ -61,7 +63,35 @@ server {
         proxy_pass http://api_server;
     }
 
+    location ^~ /nrf/side-panel {
+        # Allow the Chrome extension side panel to embed this route while
+        # keeping the rest of the app protected against clickjacking.
+        include /etc/nginx/conf.d/security_headers_embeddable.conf.inc;
+
+        # misc headers
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $host;
+
+        proxy_http_version 1.1;
+
+        # timeout settings
+        proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
+        proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
+        proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
+
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://web_server;
+    }
+
     location / {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -35,6 +35,8 @@ server {
 
     # Match both /api/* and /openapi.json in a single rule
     location ~ ^/(api|openapi.json)(/.*)?$ {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # Rewrite /api prefixed matched paths
         rewrite ^/api(/.*)$ $1 break;
 
@@ -57,7 +59,31 @@ server {
         proxy_pass http://api_server;
     }
 
+    location ^~ /nrf/side-panel {
+        # Allow the Chrome extension side panel to embed this route while
+        # keeping the rest of the app protected against clickjacking.
+        include /etc/nginx/conf.d/security_headers_embeddable.conf.inc;
+
+        # misc headers
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # don't trust client-supplied X-Forwarded-* headers - use nginx's own values
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $host;
+
+        proxy_http_version 1.1;
+
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://web_server;
+    }
+
     location / {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -80,6 +106,7 @@ server {
     listen 443 ssl default_server;
 
     client_max_body_size 5G;    # Maximum upload size
+    include /etc/nginx/conf.d/security_headers_hsts.conf.inc;
     
     location / {
         # misc headers

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -35,6 +35,8 @@ server {
 
     # Match both /api/* and /openapi.json in a single rule
     location ~ ^/(api|openapi.json)(/.*)?$ {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # Rewrite /api prefixed matched paths
         rewrite ^/api(/.*)$ $1 break;
 
@@ -62,7 +64,36 @@ server {
         proxy_pass http://api_server;
     }
 
+    location ^~ /nrf/side-panel {
+        # Allow the Chrome extension side panel to embed this route while
+        # keeping the rest of the app protected against clickjacking.
+        include /etc/nginx/conf.d/security_headers_embeddable.conf.inc;
+
+        # misc headers
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # don't trust client-supplied X-Forwarded-* headers - use nginx's own values
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header Host $host;
+
+        proxy_http_version 1.1;
+
+        # timeout settings
+        proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
+        proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
+        proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
+
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://web_server;
+    }
+
     location / {
+        include /etc/nginx/conf.d/security_headers_common.conf.inc;
+
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -94,6 +125,7 @@ server {
     listen 443 ssl default_server;
 
     client_max_body_size 5G;    # Maximum upload size
+    include /etc/nginx/conf.d/security_headers_hsts.conf.inc;
 
     location / {
         # misc headers

--- a/deployment/data/nginx/security_headers_common.conf.inc
+++ b/deployment/data/nginx/security_headers_common.conf.inc
@@ -1,0 +1,4 @@
+add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: ws: wss:; frame-src 'self' blob: data: https: http://localhost:* https://localhost:*; media-src 'self' data: blob: https:; worker-src 'self' blob:;" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;

--- a/deployment/data/nginx/security_headers_embeddable.conf.inc
+++ b/deployment/data/nginx/security_headers_embeddable.conf.inc
@@ -1,0 +1,3 @@
+add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; frame-ancestors 'self' chrome-extension:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: ws: wss:; frame-src 'self' blob: data: https: http://localhost:* https://localhost:*; media-src 'self' data: blob: https:; worker-src 'self' blob:;" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;

--- a/deployment/data/nginx/security_headers_hsts.conf.inc
+++ b/deployment/data/nginx/security_headers_hsts.conf.inc
@@ -1,0 +1,1 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -732,6 +732,15 @@ ensure_file "${INSTALL_ROOT}/deployment/env.template" \
 ensure_file "${INSTALL_ROOT}/data/nginx/app.conf.template" \
     "$NGINX_BASE_URL/app.conf.template" "nginx/app.conf.template" || exit 1
 
+ensure_file "${INSTALL_ROOT}/data/nginx/security_headers_common.conf.inc" \
+    "$NGINX_BASE_URL/security_headers_common.conf.inc" "nginx/security_headers_common.conf.inc" || exit 1
+
+ensure_file "${INSTALL_ROOT}/data/nginx/security_headers_embeddable.conf.inc" \
+    "$NGINX_BASE_URL/security_headers_embeddable.conf.inc" "nginx/security_headers_embeddable.conf.inc" || exit 1
+
+ensure_file "${INSTALL_ROOT}/data/nginx/security_headers_hsts.conf.inc" \
+    "$NGINX_BASE_URL/security_headers_hsts.conf.inc" "nginx/security_headers_hsts.conf.inc" || exit 1
+
 ensure_file "${INSTALL_ROOT}/data/nginx/run-nginx.sh" \
     "$NGINX_BASE_URL/run-nginx.sh" "nginx/run-nginx.sh" || exit 1
 chmod +x "${INSTALL_ROOT}/data/nginx/run-nginx.sh"


### PR DESCRIPTION
mplementé los headers de seguridad en Nginx con snippets reutilizables en [security_headers_common.conf.inc](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/), [security_headers_embeddable.conf.inc](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [security_headers_hsts.conf.inc](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/). Eso añade Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection y Strict-Transport-Security, con HSTS aplicado solo en HTTPS.

Los apliqué en [app.conf.template](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/), [app.conf.template.prod](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) y [app.conf.template.no-letsencrypt](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/). También dejé una excepción puntual para [/nrf/side-panel](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) para no romper el panel embebido de la extensión, y actualicé [install.sh](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/vinko/.vscode/extensions/openai.chatgpt-26.318.11754-win32-x64/webview/) para copiar los nuevos snippets al entorno instalado.