### PR TITLE
feat(deploy): add multi-tenant migration support

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -223,9 +223,18 @@ jobs:
             echo "[INFO] Waiting for services to initialize..."
             sleep 15
 
-            echo "[INFO] Starting database migrations in the background..."
-            sudo docker compose exec -d api_server alembic upgrade head 2>/dev/null || true
-            sleep 2
+            echo "[INFO] Running database migrations..."
+            MULTI_TENANT_ENABLED=$(grep -qE '^MULTI_TENANT=true' .env 2>/dev/null && echo "true" || echo "false")
+
+            if [ "$MULTI_TENANT_ENABLED" = "true" ]; then
+              echo "[INFO] Multi-tenant mode: running schema_private migrations..."
+              sudo docker compose exec -T api_server alembic -n schema_private upgrade head
+              echo "[INFO] Multi-tenant mode: running tenant schema migrations..."
+              sudo docker compose exec -T api_server alembic -x upgrade_all_tenants=true -x continue=true upgrade head
+            else
+              echo "[INFO] Single-tenant mode: running standard migrations..."
+              sudo docker compose exec -T api_server alembic upgrade head
+            fi
 
             echo "[INFO] Checking nginx-simple.conf state..."
             if [ -d nginx-simple.conf ]; then

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -7,7 +7,15 @@ services:
       context: ../../backend
       dockerfile: Dockerfile
     command: >
-      /bin/sh -c "alembic upgrade head &&
+      /bin/sh -c "
+      if [ \"$${MULTI_TENANT:-false}\" = \"true\" ]; then
+        echo 'Running schema_private migrations...' &&
+        alembic -n schema_private upgrade head &&
+        echo 'Running tenant schema migrations...' &&
+        alembic -x upgrade_all_tenants=true -x continue=true upgrade head;
+      else
+        alembic upgrade head;
+      fi &&
       echo \"Starting ACTIVA API Server\" &&
       uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
     depends_on:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -8,7 +8,14 @@ services:
       dockerfile: Dockerfile
     command: >
       /bin/sh -c "
-      alembic upgrade head &&
+      if [ \"$${MULTI_TENANT:-false}\" = \"true\" ]; then
+        echo 'Running schema_private migrations...' &&
+        alembic -n schema_private upgrade head &&
+        echo 'Running tenant schema migrations...' &&
+        alembic -x upgrade_all_tenants=true -x continue=true upgrade head;
+      else
+        alembic upgrade head;
+      fi &&
       echo \"Starting ACTIVA API Server\" &&
       uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
     depends_on:
@@ -45,6 +52,8 @@ services:
       - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
       - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
       - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+      # Multi-tenant mode
+      - MULTI_TENANT=${MULTI_TENANT:-false}
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## Summary
- Deploy workflow and docker-compose prod files now conditionally run multi-tenant migrations when `MULTI_TENANT=true` is set in `.env`
- When enabled, runs both `alembic -n schema_private upgrade head` (shared tables) and `alembic -x upgrade_all_tenants=true upgrade head` (per-tenant schemas)
- Single-tenant deployments are completely unaffected (backward compatible)
- Deploy step switched from background (`-d`) to foreground (`-T`) execution for visibility
- Rollback path also supports multi-tenant migrations

## Test plan
- [ ] Deploy with `MULTI_TENANT` unset → verify single-tenant `alembic upgrade head` runs as before
- [ ] Deploy with `MULTI_TENANT=true` in `.env` → verify both migration tracks run
- [ ] Trigger rollback → verify correct migration mode used during rollback
- [ ] Container restart → verify conditional command works on api_server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)