### PR TITLE
fix(deploy): trigger auto-rollback on deploy failure

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -439,7 +439,7 @@ jobs:
 
   auto-rollback:
     needs: [extract-version, deploy, verify]
-    if: needs.deploy.result == 'success' && needs.verify.result == 'failure'
+    if: needs.deploy.result == 'failure' || (needs.deploy.result == 'success' && needs.verify.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Auto-rollback now also triggers when the deploy step itself fails (e.g. migration error), not just when verification fails
- Previously, a deploy failure left the site down with no automatic recovery

## Context
Release 0.0.3 deploy failed due to an alembic migration conflict. The site went down and no rollback was triggered because the condition only checked for `deploy=success && verify=failure`.

## Test plan
- [ ] Deploy failure (e.g. bad migration) → confirm rollback triggers and restores previous version
- [ ] Deploy success + verify failure → confirm rollback still works as before
- [ ] Deploy success + verify success → confirm no rollback triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)