### PR TITLE
fix(migrations): resolve schema_private version table conflict

### DIFF
--- a/backend/alembic_tenants/env.py
+++ b/backend/alembic_tenants/env.py
@@ -75,6 +75,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,  # type: ignore
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        version_table="alembic_version_schema_private",
     )
 
     with context.begin_transaction():
@@ -86,6 +87,7 @@ def do_run_migrations(connection: Connection) -> None:
         connection=connection,
         target_metadata=target_metadata,  # type: ignore[arg-type]
         include_object=include_object,
+        version_table="alembic_version_schema_private",
     )
 
     with context.begin_transaction():

--- a/backend/alembic_tenants/versions/14a83a331951_create_usertenantmapping_table.py
+++ b/backend/alembic_tenants/versions/14a83a331951_create_usertenantmapping_table.py
@@ -9,7 +9,22 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(conn: sa.engine.Connection, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = :t"
+        ),
+        {"t": table_name},
+    )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
+    conn = op.get_bind()
+    if _table_exists(conn, "user_tenant_mapping"):
+        return
+
     op.create_table(
         "user_tenant_mapping",
         sa.Column("email", sa.String(), nullable=False),

--- a/backend/alembic_tenants/versions/34e3630c7f32_lowercase_multi_tenant_user_auth.py
+++ b/backend/alembic_tenants/versions/34e3630c7f32_lowercase_multi_tenant_user_auth.py
@@ -6,6 +6,8 @@ Create Date: 2025-02-26 15:03:01.211894
 
 """
 
+import sqlalchemy as sa
+
 from alembic import op
 
 
@@ -25,12 +27,22 @@ def upgrade() -> None:
         """
     )
     # 2) Add a check constraint so that emails cannot be written in uppercase
-    op.create_check_constraint(
-        "ensure_lowercase_email",
-        "user_tenant_mapping",
-        "email = LOWER(email)",
-        schema="public",
+    # (skip if it already exists from a prior migration track)
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE constraint_name = 'ensure_lowercase_email' "
+            "AND table_name = 'user_tenant_mapping'"
+        )
     )
+    if result.fetchone() is None:
+        op.create_check_constraint(
+            "ensure_lowercase_email",
+            "user_tenant_mapping",
+            "email = LOWER(email)",
+            schema="public",
+        )
 
 
 def downgrade() -> None:

--- a/backend/alembic_tenants/versions/3b45e0018bf1_add_new_available_tenant_table.py
+++ b/backend/alembic_tenants/versions/3b45e0018bf1_add_new_available_tenant_table.py
@@ -18,8 +18,22 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(conn: sa.engine.Connection, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = :t"
+        ),
+        {"t": table_name},
+    )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
-    # Create new_available_tenant table
+    conn = op.get_bind()
+    if _table_exists(conn, "available_tenant"):
+        return
+
     op.create_table(
         "available_tenant",
         sa.Column("tenant_id", sa.String(), nullable=False),

--- a/backend/alembic_tenants/versions/a4f6ee863c47_mapping_for_anonymous_user_path.py
+++ b/backend/alembic_tenants/versions/a4f6ee863c47_mapping_for_anonymous_user_path.py
@@ -18,7 +18,22 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(conn: sa.engine.Connection, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = :t"
+        ),
+        {"t": table_name},
+    )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
+    conn = op.get_bind()
+    if _table_exists(conn, "tenant_anonymous_user_path"):
+        return
+
     op.create_table(
         "tenant_anonymous_user_path",
         sa.Column("tenant_id", sa.String(), primary_key=True, nullable=False),

--- a/backend/alembic_tenants/versions/ac842f85f932_new_column_user_tenant_mapping.py
+++ b/backend/alembic_tenants/versions/ac842f85f932_new_column_user_tenant_mapping.py
@@ -18,23 +18,52 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade() -> None:
-    # Add active column with default value of True
-    op.add_column(
-        "user_tenant_mapping",
-        sa.Column(
-            "active",
-            sa.Boolean(),
-            nullable=False,
-            server_default="true",
+def _column_exists(
+    conn: sa.engine.Connection, table_name: str, column_name: str
+) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = :t "
+            "AND column_name = :c"
         ),
-        schema="public",
+        {"t": table_name, "c": column_name},
     )
+    return result.fetchone() is not None
 
-    op.drop_constraint("uq_email", "user_tenant_mapping", schema="public")
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Add active column with default value of True (skip if already exists)
+    if not _column_exists(conn, "user_tenant_mapping", "active"):
+        op.add_column(
+            "user_tenant_mapping",
+            sa.Column(
+                "active",
+                sa.Boolean(),
+                nullable=False,
+                server_default="true",
+            ),
+            schema="public",
+        )
+
+    # Drop uq_email constraint if it exists
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE constraint_name = 'uq_email' "
+            "AND table_name = 'user_tenant_mapping'"
+        )
+    )
+    if result.fetchone() is not None:
+        op.drop_constraint("uq_email", "user_tenant_mapping", schema="public")
 
     # Create a unique index for active=true records
     # This ensures a user can only be active in one tenant at a time
+    op.execute(
+        "DROP INDEX IF EXISTS uq_user_active_email_idx"
+    )
     op.execute(
         "CREATE UNIQUE INDEX uq_user_active_email_idx ON public.user_tenant_mapping (email) WHERE active = true"
     )


### PR DESCRIPTION
## Summary
- **Root cause of release-0.0.3 deploy failure**: the `schema_private` alembic track (`alembic_tenants/`) shared the same `alembic_version` table as the main track, so `alembic -n schema_private upgrade head` failed with `Can't locate revision '689433b0d8de'`
- Use a separate `alembic_version_schema_private` table for the `schema_private` track
- Make all tenant migrations idempotent (IF NOT EXISTS guards) since the main track migration `0ace679199f4` already creates the same tables (`user_tenant_mapping`, `available_tenant`, `tenant_anonymous_user_path`)

## Files changed
- `backend/alembic_tenants/env.py` — set `version_table="alembic_version_schema_private"`
- `backend/alembic_tenants/versions/*.py` — add idempotency guards to 5 migrations

## Test plan
- [ ] Run `alembic -n schema_private upgrade head` on a DB that already has the main track migrated — should succeed without errors
- [ ] Run `alembic -n schema_private upgrade head` on a fresh DB — should create tables normally
- [ ] Verify `alembic_version_schema_private` table is created separately from `alembic_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)