### PR TITLE
fix(users): skip billing when no control plane and refresh invite list

### DIFF
--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -47,6 +47,8 @@ from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.auth import get_live_users_count
 from onyx.db.engine.sql_engine import get_session
@@ -502,6 +504,21 @@ def bulk_invite_users(
             fetch_ee_implementation_or_noop(
                 "onyx.server.tenants.billing", "register_tenant_users", None
             )(tenant_id, get_live_users_count(db_session))
+        except OnyxError as e:
+            if e.error_code == OnyxErrorCode.NOT_IMPLEMENTED:
+                # No control plane configured — billing tracking is not available,
+                # but the invite itself should still succeed.
+                logger.info("Billing not configured, skipping seat registration.")
+            else:
+                logger.error(f"Failed to register tenant users: {str(e)}")
+                logger.info(
+                    "Reverting changes: removing users from tenant and resetting invited users"
+                )
+                write_invited_users(initial_invited_users)  # Reset to original state
+                fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.user_mapping", "remove_users_from_tenant", None
+                )(new_invited_emails, tenant_id)
+                raise e
         except Exception as e:
             logger.error(f"Failed to register tenant users: {str(e)}")
             logger.info(
@@ -537,6 +554,15 @@ def remove_invited_user(
             fetch_ee_implementation_or_noop(
                 "onyx.server.tenants.billing", "register_tenant_users", None
             )(tenant_id, get_live_users_count(db_session))
+    except OnyxError as e:
+        if e.error_code == OnyxErrorCode.NOT_IMPLEMENTED:
+            logger.info("Billing not configured, skipping seat registration.")
+        else:
+            logger.error(
+                "Request to update number of seats taken in control plane failed. "
+                "This may cause synchronization issues/out of date enforcement of seat limits."
+            )
+            raise e
     except Exception:
         logger.error(
             "Request to update number of seats taken in control plane failed. "

--- a/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useSWRConfig } from "swr";
 import { Button } from "@opal/components";
 import { SvgUsers, SvgAlertTriangle } from "@opal/icons";
 import { Disabled } from "@opal/core";
@@ -34,6 +35,7 @@ export default function InviteUsersModal({
   open,
   onOpenChange,
 }: InviteUsersModalProps) {
+  const { mutate } = useSWRConfig();
   const [chips, setChips] = useState<ChipItem[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -117,6 +119,8 @@ export default function InviteUsersModal({
     setIsSubmitting(true);
     try {
       await inviteUsers(validEmails);
+      mutate("/api/manage/users/invited");
+      mutate("/api/manage/users/counts");
       toast.success(
         `Invited ${validEmails.length} user${validEmails.length > 1 ? "s" : ""}`
       );


### PR DESCRIPTION
## Summary

- **Backend**: `bulk_invite_users` and `remove_invited_user` now catch `OnyxError(NOT_IMPLEMENTED)` from `register_tenant_users` and skip gracefully instead of reverting the operation. Self-hosted deployments without a Stripe/control plane configured can now invite and cancel invites without errors.
- **Backend**: Real billing or network failures still trigger the full revert/error path as before.
- **Frontend**: `InviteUsersModal` now calls SWR global `mutate` on `/api/manage/users/invited` and `/api/manage/users/counts` after a successful invite, so the user table and summary counts refresh immediately without a page reload.

## Test plan

- [ ] Invite a user as an admin — should succeed, invited user appears in table immediately
- [ ] Cancel an invite — should succeed without billing error, user removed from table
- [ ] Verify no regression when a real billing error occurs (revert still happens)
- [ ] Verify email invite is sent with correct `WEB_DOMAIN` link (requires `WEB_DOMAIN` and Brevo SMTP env vars set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)