### PR TITLE
fix(deploy): move nginx into compose and fix port conflict on deploy

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -210,6 +210,9 @@ jobs:
 
             echo "[INFO] Stopping current services..."
             sudo docker compose down --remove-orphans
+            # Remove any standalone proxy containers that may be holding ports 80/443
+            sudo docker stop "$PROXY_CONTAINER" 2>/dev/null || true
+            sudo docker rm "$PROXY_CONTAINER" 2>/dev/null || true
             sudo docker stop "$LEGACY_PROXY_CONTAINER" 2>/dev/null || true
             sudo docker rm "$LEGACY_PROXY_CONTAINER" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

Two related fixes that must ship together:

**1. nginx managed by docker compose** (previously in #155)
- `hop-proxy` was started via a standalone `docker run` outside of compose. Any `docker compose down` on the server permanently killed it — requiring manual recreation every time.
- Updated `docker-compose.prod.yml` to use `nginx:alpine` with `nginx-simple.conf` directly, matching the production setup.
- Removed the manual `docker stop/rm/run hop-proxy` steps from deploy and rollback workflows.

**2. Evict standalone proxy before compose up**
- The first deploy after the nginx-in-compose change failed with `Bind for 0.0.0.0:80 failed: port is already allocated` because the old `hop-proxy` container was still running on the server.
- Restores `docker stop/rm $PROXY_CONTAINER` in the teardown step to evict any leftover standalone container before compose starts. After this transition deploy it becomes a no-op.

## Test plan

- [ ] Deploy succeeds — `hop-nginx-1` starts under compose without port conflict
- [ ] `docker compose down && docker compose up -d` brings nginx back automatically
- [ ] SSL/HTTPS still works (letsencrypt mounts unchanged)
- [ ] Rollback works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)