### PR TITLE
fix(deploy): sync victoriametrics and grafana config dirs to server

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -192,6 +192,10 @@ jobs:
               exit 1
             fi
 
+            echo "[INFO] Syncing supporting config directories..."
+            cp -r deployment/docker_compose/victoriametrics ./victoriametrics
+            cp -r deployment/docker_compose/grafana ./grafana
+
             echo "[INFO] Validating deployment prerequisites..."
             if [ ! -f nginx-simple.conf ]; then
               echo "[ERROR] Missing nginx-simple.conf in $(pwd)"


### PR DESCRIPTION
## Summary

`victoriametrics` was crash-looping on every deploy with `read /etc/victoriametrics/scrape.yml: is a directory`. The deploy script only copied `docker-compose.prod.yml` to the server but not the supporting config directories it mounts. When Docker tried to bind-mount a file that didn't exist on the host, it created an empty directory instead.

Adds `cp -r` for `victoriametrics/` and `grafana/` alongside the compose file copy step so all required configs are present before `docker compose up`.

## Test plan

- [ ] Deploy succeeds with `hop-victoriametrics-1` staying up
- [ ] Grafana dashboards and provisioning load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)