### PR TITLE
fix(ui): restyle CreateCompanyCard to match sibling Card component

### DIFF
--- a/web/src/refresh-pages/admin/CompaniesPage.tsx
+++ b/web/src/refresh-pages/admin/CompaniesPage.tsx
@@ -273,32 +273,21 @@ function CreateCompanyCard({
   }
 
   return (
-    <div className="rounded-20 border border-[color:var(--landing-border)] bg-[color:var(--landing-card)] p-5 shadow-[0_26px_60px_-36px_rgba(33,64,120,0.52)] backdrop-blur-sm">
-      <div className="rounded-16 border border-[color:var(--landing-border)] bg-[image:var(--landing-card-tint)] p-5">
-        <div className="flex flex-col gap-2">
-          <div className="inline-flex w-fit rounded-full border border-[color:var(--landing-border)] bg-[var(--landing-accent-pale)] px-3 py-1">
-            <Text
-              as="span"
-              className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--landing-accent-strong)]"
-            >
-              {t("companies.create.badge")}
+    <Card padding={0} gap={0}>
+      <div className="flex flex-col gap-4 p-5">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <SvgPlusCircle className="h-4 w-4 stroke-text-03" />
+            <Text mainAction text01>
+              {t("companies.create.title")}
             </Text>
           </div>
-          <Text
-            as="p"
-            className="text-[1.4rem] font-semibold tracking-[-0.04em] text-[var(--landing-text)]"
-          >
-            {t("companies.create.title")}
-          </Text>
-          <Text
-            as="p"
-            className="text-sm leading-7 text-[var(--landing-muted)]"
-          >
+          <Text secondaryBody text03>
             {t("companies.create.description")}
           </Text>
         </div>
 
-        <form className="flex flex-col gap-4 pt-6" onSubmit={handleSubmit}>
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
           <FormField label={t("companies.fields.companyName")}>
             <InputTypeIn
               value={name}
@@ -340,7 +329,7 @@ function CreateCompanyCard({
           </div>
         </form>
       </div>
-    </div>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replaced the custom landing-style nested divs in `CreateCompanyCard` with the standard `Card` component
- Uses design system tokens (`Text`, `SvgPlusCircle`, color classes) to match the styling of sibling company cards in `/admin/companies`

## Test plan
- [ ] Navigate to `/admin/companies` and verify the "New Company" card visually matches its siblings

🤖 Generated with [Claude Code](https://claude.com/claude-code)