### PR TITLE
feat(companies): add resend invite button for pending users

### DIFF
--- a/web/src/lib/i18n/app-language.ts
+++ b/web/src/lib/i18n/app-language.ts
@@ -274,6 +274,7 @@ const translations = {
     "companies.buttons.saving": "Saving...",
     "companies.buttons.inviteAdmin": "Invite admin",
     "companies.buttons.sending": "Sending...",
+    "companies.buttons.resendInvite": "Send invite",
     "companies.roster.title": "Company roster",
     "companies.roster.description":
       "Select a company to inspect users, adjust metadata, or change activation state.",
@@ -621,6 +622,7 @@ const translations = {
     "companies.buttons.saving": "Guardando...",
     "companies.buttons.inviteAdmin": "Invitar admin",
     "companies.buttons.sending": "Enviando...",
+    "companies.buttons.resendInvite": "Enviar invitacion",
     "companies.roster.title": "Listado de empresas",
     "companies.roster.description":
       "Selecciona una empresa para inspeccionar usuarios, ajustar metadata o cambiar su activacion.",

--- a/web/src/refresh-pages/admin/CompaniesPage.tsx
+++ b/web/src/refresh-pages/admin/CompaniesPage.tsx
@@ -333,8 +333,24 @@ function CreateCompanyCard({
   );
 }
 
-function CompanyUsersList({ users }: { users: CompanyUserSnapshot[] }) {
+interface CompanyUsersListProps {
+  users: CompanyUserSnapshot[];
+  onResendInvite?: (email: string) => Promise<void>;
+}
+
+function CompanyUsersList({ users, onResendInvite }: CompanyUsersListProps) {
   const { t } = useAppLanguage();
+  const [resendingEmail, setResendingEmail] = useState<string | null>(null);
+
+  async function handleResend(email: string) {
+    if (!onResendInvite || resendingEmail) return;
+    setResendingEmail(email);
+    try {
+      await onResendInvite(email);
+    } finally {
+      setResendingEmail(null);
+    }
+  }
 
   if (!users.length) {
     return (
@@ -363,9 +379,23 @@ function CompanyUsersList({ users }: { users: CompanyUserSnapshot[] }) {
                 : t("companies.users.pendingRegistration")}
             </Text>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Tag label={roleLabel(user.role, t)} />
             <Tag label={userStatusLabel(user, t)} />
+            {!user.registered && onResendInvite ? (
+              <Disabled disabled={resendingEmail !== null}>
+                <Button
+                  size="sm"
+                  prominence="tertiary"
+                  icon={SvgUserPlus}
+                  onClick={() => handleResend(user.email)}
+                >
+                  {resendingEmail === user.email
+                    ? t("companies.buttons.sending")
+                    : t("companies.buttons.resendInvite")}
+                </Button>
+              </Disabled>
+            ) : null}
           </div>
         </div>
       ))}
@@ -639,7 +669,10 @@ function CompanyDetailPanel({
             {t("companies.detail.usersInCompany")}
           </Text>
         </div>
-        <CompanyUsersList users={currentCompany.users} />
+        <CompanyUsersList
+          users={currentCompany.users}
+          onResendInvite={onInviteAdmin}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a "Send invite" button on each user row in the company detail panel where the invite is still pending (user has not registered yet)
- Clicking the button re-calls `POST /admin/companies/{id}/invite-admin`, which resends the invite email
- Button is disabled while a resend is in flight; shows "Sending..." for the specific row being resent
- No button is shown for already-registered users

## Test plan
- [ ] Open a company detail panel that has pending (unregistered) users — verify "Send invite" button appears on those rows
- [ ] Registered users should have no button
- [ ] Click "Send invite" — verify the invited email receives the invite and the toast shows "Admin invitation sent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)