### PR TITLE
fix(ui): correct Text prop mainAction -> mainUiAction in CreateCompanyCard

### DIFF
--- a/web/src/refresh-pages/admin/CompaniesPage.tsx
+++ b/web/src/refresh-pages/admin/CompaniesPage.tsx
@@ -278,7 +278,7 @@ function CreateCompanyCard({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <SvgPlusCircle className="h-4 w-4 stroke-text-03" />
-            <Text mainAction text01>
+            <Text mainUiAction text01>
               {t("companies.create.title")}
             </Text>
           </div>


### PR DESCRIPTION
## Summary
- Fixes TypeScript build error introduced in the CreateCompanyCard styling refactor
- `mainAction` is not a valid `Text` prop — the correct prop is `mainUiAction`

## Test plan
- [ ] Web Docker build completes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)