### PR TITLE
fix(deploy): use rsync to sync config dirs and prevent nesting on redeploy

### DIFF
--- a/.github/workflows/deploy-digitalocean-release.yml
+++ b/.github/workflows/deploy-digitalocean-release.yml
@@ -193,8 +193,9 @@ jobs:
             fi
 
             echo "[INFO] Syncing supporting config directories..."
-            cp -r deployment/docker_compose/victoriametrics ./victoriametrics
-            cp -r deployment/docker_compose/grafana ./grafana
+            mkdir -p ./victoriametrics ./grafana
+            rsync -a --delete deployment/docker_compose/victoriametrics/ ./victoriametrics/
+            rsync -a --delete deployment/docker_compose/grafana/ ./grafana/
 
             echo "[INFO] Validating deployment prerequisites..."
             if [ ! -f nginx-simple.conf ]; then


### PR DESCRIPTION
## Summary
- Replaces `cp -r` with `rsync -a --delete` when syncing `victoriametrics/` and `grafana/` config directories to the server
- `cp -r src ./dst` when `./dst` already exists copies the source directory *inside* the destination, creating `./dst/src/` nesting on every redeploy — this broke VictoriaMetrics and Grafana provisioning
- `rsync -a src/ dst/` (trailing slashes) always syncs contents directly into the destination regardless of whether it already exists

## Test plan
- [ ] Deploy to production and verify `ls /opt/onyx/victoriametrics/` shows `scrape.yml` as a file, not a directory
- [ ] Verify VictoriaMetrics starts cleanly on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)