### PR TITLE
fix(vespa): add content-cluster-removal override to allow cluster rename

### DIFF
--- a/backend/onyx/document_index/vespa/app_config/validation-overrides.xml.jinja
+++ b/backend/onyx/document_index/vespa/app_config/validation-overrides.xml.jinja
@@ -5,7 +5,10 @@
     <allow
         until="{{ until_date }}"
         comment="We need to be able to update the schema for updates to the Onyx schema">indexing-change</allow>
-    <allow 
+    <allow
         until="{{ until_date }}"
         comment="Prevents old alt indices from interfering with changes">field-type-change</allow>
+    <allow
+        until="{{ until_date }}"
+        comment="Allow renaming content clusters (e.g. danswer_index -> onyx_index) without blocking deployment">content-cluster-removal</allow>
 </validation-overrides>


### PR DESCRIPTION
## Summary
- Vespa was returning `400 INVALID_APPLICATION_PACKAGE` on every api_server startup because the new schema renames the content cluster from `danswer_index` to `onyx_index`
- Vespa requires an explicit `content-cluster-removal` validation override to allow this (to prevent accidental data loss)
- Without this, the Vespa schema is never deployed, and file vector indexing fails with `400 Bad Request` on every write

## Test plan
- [ ] Deploy to prod and confirm api_server Vespa setup succeeds (look for "Vespa setup complete." in api_server logs)
- [ ] Re-upload a file and confirm it reaches COMPLETED status

🤖 Generated with [Claude Code](https://claude.com/claude-code)