### PR TITLE
fix(files): keep INDEXING status when Phase 2 vector indexing fails

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -451,8 +451,11 @@ def _process_user_file_with_indexing(
         task_logger.error(
             f"_process_user_file_with_indexing - Indexing pipeline failed id={user_file_id}"
         )
-        if uf.status != UserFileStatus.DELETING:
-            uf.status = UserFileStatus.FAILED
+        # Leave status as INDEXING rather than FAILED — Phase 1 (text extraction)
+        # already succeeded so the file is usable in chat via direct text
+        # injection.  Only vector-based RAG search is unavailable.
+        if uf.status not in (UserFileStatus.DELETING, UserFileStatus.INDEXING):
+            uf.status = UserFileStatus.INDEXING
             db_session.add(uf)
             db_session.commit()
         raise RuntimeError(f"Indexing pipeline failed for user file {user_file_id}")


### PR DESCRIPTION
## Summary
- When Phase 1 (text extraction) succeeds but Phase 2 (Vespa vector indexing) fails, the file status was set to FAILED
- This hid the file from the UI (`/user/files/recent` filters out FAILED), even though the file is usable in chat via direct text injection
- Now the status stays as INDEXING, keeping the file visible and usable
- The outer try/except already expected this behavior (its warning message says "INDEXING status")

## Test plan
- [ ] Upload a file, verify it reaches COMPLETED when vector indexing succeeds
- [ ] If vector indexing fails (e.g. Vespa down), verify file shows as INDEXING in My Files, not hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)