### PR TITLE
fix(deploy): disable celery-exporter to prevent worker deadlocks

### DIFF
--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -586,29 +586,35 @@ services:
         max-size: "50m"
         max-file: "6"
 
-  celery-exporter:
-    image: ghcr.io/danihodovic/celery-exporter:latest
-    restart: unless-stopped
-    depends_on:
-      - cache
-    deploy:
-      resources:
-        limits:
-          cpus: '0.25'
-          memory: 128M
-        reservations:
-          cpus: '0.10'
-          memory: 32M
-    environment:
-      - CE_BROKER_URL=${CELERY_EXPORTER_BROKER_URL:-redis://cache:6379/${REDIS_DB_NUMBER_CELERY:-15}}
-      - CE_RETRY_INTERVAL=5
-    expose:
-      - "9808"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
+  # celery-exporter is disabled because it continuously sends inspect commands
+  # via the Celery pidbox control channel. Combined with CELERY_SEPARATOR=":"
+  # in our Celery config, this causes kombu to write malformed pidbox binding
+  # entries that crash workers with:
+  #   ValueError: not enough values to unpack (expected 3, got 1)
+  # Re-enable only after resolving the separator/pidbox compatibility issue.
+  # celery-exporter:
+  #   image: ghcr.io/danihodovic/celery-exporter:latest
+  #   restart: unless-stopped
+  #   depends_on:
+  #     - cache
+  #   deploy:
+  #     resources:
+  #       limits:
+  #         cpus: '0.25'
+  #         memory: 128M
+  #       reservations:
+  #         cpus: '0.10'
+  #         memory: 32M
+  #   environment:
+  #     - CE_BROKER_URL=${CELERY_EXPORTER_BROKER_URL:-redis://cache:6379/${REDIS_DB_NUMBER_CELERY:-15}}
+  #     - CE_RETRY_INTERVAL=5
+  #   expose:
+  #     - "9808"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
 
   dozzle:
     image: amir20/dozzle:latest

--- a/deployment/docker_compose/victoriametrics/scrape.yml
+++ b/deployment/docker_compose/victoriametrics/scrape.yml
@@ -24,10 +24,10 @@ scrape_configs:
     static_configs:
       - targets: ["redis-exporter:9121"]
 
-  # Celery exporter (#85)
-  - job_name: celery
-    static_configs:
-      - targets: ["celery-exporter:9808"]
+  # Celery exporter disabled — see docker-compose.prod.yml comment
+  # - job_name: celery
+  #   static_configs:
+  #     - targets: ["celery-exporter:9808"]
 
   # FastAPI /metrics endpoint (#86)
   - job_name: fastapi


### PR DESCRIPTION
## Summary
- celery-exporter continuously sends inspect commands via the Celery pidbox control channel
- Combined with `CELERY_SEPARATOR=":"` in our Celery config, kombu writes malformed pidbox binding entries
- Workers crash with `ValueError: not enough values to unpack (expected 3, got 1)` and deadlock
- This has been the recurring root cause of file indexing failures in prod — every time the exporter restarts, workers die
- Comments out the exporter service and its VictoriaMetrics scrape target

## Test plan
- [ ] Deploy and verify workers stay healthy over 24h
- [ ] Verify file upload + indexing completes successfully
- [ ] Verify no `ValueError` in background worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)